### PR TITLE
Configurability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ termchan
 # sample dbs and query collections for development
 *.db
 *.sql
+# config files for testing
+*.json

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A simple text board, powered by Golang's stdlib http server and sqlite.
 
-## Installation
+## Running and Configuring
 
 Making sure you have the go tool installed and set up, just do
 
@@ -12,7 +12,37 @@ Making sure you have the go tool installed and set up, just do
 go get -u github.com/fgahr/termchan
 ```
 
-Afterwards, build the project with `go build`, then run with `./termchan`
+Afterwards, build the project with `go build`, then run it
+
+```sh
+$ termchan help
+usage: ./termchan [-d dir] <command>
+
+flags:
+  -d <dir>            Set the directory from which to run, defaults to the current directory
+
+commands:
+  dump-config         Write the current configuration to stdout; can be used to populate a default config
+  create-templates    Place the default templates; will not overwrite existing files
+  serve-http          Run as an http service
+
+```
+
+The server will read a `config.json` file, a template of which can be created via
+
+```sh
+$ termchan dump-config > config.json
+```
+
+The list of boards can be adjusted in `config.json`, using the example board
+as a template. After changing the configuration, restart the server or send a
+SIGHUP signal, e.g.
+
+```sh
+$ kill -s HUP $(pgrep termchan)
+```
+
+to make it reload its config.
 
 ## Overview
 
@@ -77,42 +107,6 @@ Post (i.e. create) a thread (*)
 HAVE FUN!
 ```
 
-## Setup
-
-```sh
-termchan -h
-Usage of termchan:
-  -d string
-    	the base (configuration) directory for the service (default "./")
-  -p int
-    	the port for the server to listen on (default 8088)
-  -t  when given, create templates to adjust appearance
-```
-
-The server will read or create a `config.db` config file and a `boards`
-directory to store the database files for the individual boards. When the `-t`
-option is given, a `template/` directory will be created with default templates.
-See below for [configuration](#config).
-
-You can add new boards to the `config.db` file with the sqlite3 command and
-
-```sh
-INSERT INTO board (name, description, style)
-VALUES ('a', 'a board', 'red');
-```
-
-Defining a style is optional but recommended. Recognized style names are, as
-of writing, `none`, `black`, `red`, `green`, `yellow`, `blue`, `magenta`,
-`cyan`, and `white`.
-
-After changing the board list, restart the server or send a SIGHUP signal, e.g.
-
-```sh
-kill -s HUP $(pgrep termchan)
-```
-
-to make it reload its config.
-
 ## Usage
 
 ### With tccli
@@ -162,21 +156,43 @@ $ curl -s 'localhost:8088/b?format=json' | jq
 }
 ```
 
-<a name="config">
+## Advanced
 
-# Configuration
+### Appearance
 
 The appearance of termchan can be changed via [templates](https://golang.org/pkg/text/template/). These are part of Go's
 standard library. To support both terminal and html output, both `text/template`
 and `html/template` are used. The packages `tchan/output/ansi` and
 `tchan/output/html` are mostly mirrored and either one is suitable to learn
-about available fields and functions from within the template.
+about available fields and functions from within the template. Running
 
-When a template is missing, its default is used (embedded in the source). To
-use a new or edited template, restart termchan or send a `SIGHUP` signal to a
-running process.
+```sh
+$ termchan create-templates
+```
 
-# TODOs
+will dump the integrated defaults as files inside a `template/` folder. Already
+existing files will not be overwritten. If you delete a template, its default
+will be used when running termchan.
+
+### Domain Socket Connections
+
+In the `config.json` file, the default transport type is `tcp` on `:8088`.
+However, for reverse proxy setups, connection via a domain socket can be used.
+E.g.
+```
+...
+	"transport": {
+		"Protocol": "unix",
+		"Socket": "/tmp/termchan/socket"
+	},
+...
+```
+
+## TODOs
 
 - Enable banning of users (requires re-enabling tracking of IP addresses, should
   probably mention that in the welcome message)
+- Basic security measures
+- More available styles (e.g. bold)
+- Enable editing CSS for html output
+- Whatever reasonable request you might open an issue for (pull-requests welcome)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ flags:
   -d <dir>            Set the directory from which to run, defaults to the current directory
 
 commands:
+  help                Show this message
   dump-config         Write the current configuration to stdout; can be used to populate a default config
   create-templates    Place the default templates; will not overwrite existing files
   serve-http          Run as an http service
@@ -50,7 +51,7 @@ When accessing `/` without any parameters, you will be greeted with a banner and
 usage information. An example of HTML output for the banner is
 [here](welcome.html).
 
-```
+`````
 $ curl -s 'localhost:8088/'
   ::::::::::::.,:::::: :::::::..   .        :
   ;;;;;;;;'''';;;;'''' ;;;;``;;;;  ;;,.    ;;;
@@ -105,7 +106,7 @@ Post (i.e. create) a thread (*)
 (*) fields other than content are optional, board/thread has to exist
 ================================================================================
 HAVE FUN!
-```
+`````
 
 ## Usage
 
@@ -179,6 +180,7 @@ will be used when running termchan.
 In the `config.json` file, the default transport type is `tcp` on `:8088`.
 However, for reverse proxy setups, connection via a domain socket can be used.
 E.g.
+
 ```
 ...
 	"transport": {

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ When accessing `/` without any parameters, you will be greeted with a banner and
 usage information. An example of HTML output for the banner is
 [here](welcome.html).
 
-`````
+```
 $ curl -s 'localhost:8088/'
   ::::::::::::.,:::::: :::::::..   .        :
   ;;;;;;;;'''';;;;'''' ;;;;``;;;;  ;;,.    ;;;
@@ -106,7 +106,7 @@ Post (i.e. create) a thread (*)
 (*) fields other than content are optional, board/thread has to exist
 ================================================================================
 HAVE FUN!
-`````
+```
 
 ## Usage
 
@@ -187,6 +187,29 @@ E.g.
 		"Protocol": "unix",
 		"Socket": "/tmp/termchan/socket"
 	},
+...
+```
+
+### Board Settings
+
+Boards have associated limits (#active threads, #posts/thread, #bytes/post) with
+defaults (50, 100, 4096). The post limit is ensured before posting and
+larger posts will be rejected. Threads can always be viewed and replied to but
+only those within the limits are shown when viewing a board.
+
+Limits can be set in `config.json` through fields which are not shown by
+default. When omitted or invalid (e.g. negative numbers), defaults are used.
+
+```
+... 
+    {
+      "name": "f",
+      "description": "foo",
+      "style": "blue",
+      "maxThreads": 42,
+      "maxThreadLength": 69,
+      "maxPostBytes": 1337
+    }
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ A simple text board, powered by Golang's stdlib http server and sqlite.
 
 Making sure you have the go tool installed and set up, just do
 
-```sh
+```
 go get -u github.com/fgahr/termchan
 ```
 
 Afterwards, build the project with `go build`, then run it
 
-```sh
+```
 $ termchan help
 usage: ./termchan [-d dir] <command>
 
@@ -30,7 +30,7 @@ commands:
 
 The server will read a `config.json` file, a template of which can be created via
 
-```sh
+```
 $ termchan dump-config > config.json
 ```
 
@@ -38,7 +38,7 @@ The list of boards can be adjusted in `config.json`, using the example board
 as a template. After changing the configuration, restart the server or send a
 SIGHUP signal, e.g.
 
-```sh
+```
 $ kill -s HUP $(pgrep termchan)
 ```
 
@@ -50,7 +50,7 @@ When accessing `/` without any parameters, you will be greeted with a banner and
 usage information. An example of HTML output for the banner is
 [here](welcome.html).
 
-```sh
+```
 $ curl -s 'localhost:8088/'
   ::::::::::::.,:::::: :::::::..   .        :
   ;;;;;;;;'''';;;;'''' ;;;;``;;;;  ;;,.    ;;;
@@ -118,7 +118,7 @@ common operations without needing to interact with `curl` directly.
 
 Assuming the server is listening on port 8088 and has a board `/b/`, post with
 
-```sh
+```
 $ curl -s 'localhost:8088/b'  \
       --data-urlencode "name=me" \
       --data-urlencode "content=This is my first post"
@@ -134,7 +134,7 @@ This is my first post
 You will be greeted with a JSON view of the newly created thread. You can get an
 overview of the board with
 
-```sh
+```
 $ curl -s 'localhost:8088/b?format=json' | jq
 {
   "name": "b",
@@ -166,7 +166,7 @@ and `html/template` are used. The packages `tchan/output/ansi` and
 `tchan/output/html` are mostly mirrored and either one is suitable to learn
 about available fields and functions from within the template. Running
 
-```sh
+```
 $ termchan create-templates
 ```
 

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ flags:
   -d <dir>            Set the directory from which to run, defaults to the current directory
 
 commands:
+  help                Show this message
   dump-config         Write the current configuration to stdout; can be used to populate a default config
   create-templates    Place the default templates; will not overwrite existing files
   serve-http          Run as an http service

--- a/main.go
+++ b/main.go
@@ -28,12 +28,12 @@ func usage(out io.Writer) {
 	fmt.Fprintf(out, "usage: %s [-d dir] <command>\n", os.Args[0])
 	fmt.Fprint(out, `
 flags:
-  -d <dir>            the directory from which to run, defaults to the current directory
+  -d <dir>            Set the directory from which to run, defaults to the current directory
 
 commands:
-  dump-config         write the current configuration to stdout; can be used to populate a default config
-  create-templates    place the default templates; will not overwrite existing files
-  serve-http          run as an http service
+  dump-config         Write the current configuration to stdout; can be used to populate a default config
+  create-templates    Place the default templates; will not overwrite existing files
+  serve-http          Run as an http service
 
 `)
 }

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func serveHTTP(conf config.Settings, cmd string, args ...string) error {
 	}
 
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGHUP, syscall.SIGINT)
+	signal.Notify(sigChan, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
 	defer close(sigChan)
 	go func() {
 		for sig := range sigChan {
@@ -67,7 +67,7 @@ func serveHTTP(conf config.Settings, cmd string, args ...string) error {
 			switch sig {
 			case syscall.SIGHUP:
 				err = srv.ReloadConfig()
-			case syscall.SIGINT:
+			case syscall.SIGINT, syscall.SIGTERM:
 				err = srv.Stop()
 			default:
 				err = errors.Errorf("Unexpected signal: %v", sig)

--- a/tchan/backend/backend.go
+++ b/tchan/backend/backend.go
@@ -30,6 +30,6 @@ type DB interface {
 }
 
 // New creates a new backend which has yet to be initialized.
-func New(opts *config.Opts) DB {
+func New(opts *config.Settings) DB {
 	return &sqlite{conf: opts}
 }

--- a/tchan/backend/sqlite3.go
+++ b/tchan/backend/sqlite3.go
@@ -3,7 +3,6 @@ package backend
 import (
 	"database/sql"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/fgahr/termchan/tchan"
@@ -16,13 +15,13 @@ import (
 )
 
 type sqlite struct {
-	conf            *config.Opts
+	conf            *config.Settings
 	boardsDirectory string
 	boardDBs        map[string]*sql.DB
 }
 
 func (s *sqlite) Init() error {
-	s.boardsDirectory = filepath.Join(s.conf.WorkingDirectory, "boards")
+	s.boardsDirectory = s.conf.BoardsDirectory()
 	if ok, err := util.DirExists(s.boardsDirectory); err != nil {
 		return errors.Wrap(err, "unable to check out board DB directory")
 	} else if !ok {
@@ -81,7 +80,7 @@ FROM thread t INNER JOIN post op ON t.op_id = op.id
 AND t.num_replies > -1 AND t.num_replies <= ?
 ORDER BY t.active_at DESC
 LIMIT ?;
-`, bconf.MaxThreadLength, bconf.MaxThreadCount)
+`, bconf.MaxThreadLength(), bconf.MaxThreads())
 	if err != nil {
 		return errors.Wrap(err, "failed to gather thread summaries")
 	}

--- a/tchan/config/config.go
+++ b/tchan/config/config.go
@@ -70,8 +70,8 @@ func (p *Protocol) UnmarshalJSON(b []byte) error {
 }
 
 type Transport struct {
-	Protocol Protocol
-	Socket   string
+	Protocol Protocol `json:"protocol"`
+	Socket   string   `json:"socket"`
 }
 
 func (t Transport) String() string {
@@ -155,6 +155,7 @@ func (s *Settings) ReadFromFile() error {
 	if exists, err := util.FileExists(cf); err != nil {
 		return errors.Wrapf(err, "error looking for config file %s", cf)
 	} else if !exists {
+		// No error, just use defaults.
 		return nil
 	}
 

--- a/tchan/config/config_test.go
+++ b/tchan/config/config_test.go
@@ -6,10 +6,10 @@ import (
 	"github.com/fgahr/termchan/tchan"
 )
 
-func confWithBoards(boards ...string) Opts {
-	c := Opts{}
+func confWithBoards(boards ...string) Settings {
+	c := Settings{}
 	for _, b := range boards {
-		c.Boards = append(c.Boards, tchan.BoardConfig{Name: b})
+		c.Boards = append(c.Boards, tchan.Board{Name: b})
 	}
 	return c
 }

--- a/tchan/http/worker.go
+++ b/tchan/http/worker.go
@@ -17,7 +17,7 @@ import (
 )
 
 type requestWorker struct {
-	conf    *config.Opts
+	conf    *config.Settings
 	w       output.Writer
 	r       *http.Request
 	params  url.Values
@@ -117,7 +117,7 @@ func (rw *requestWorker) extractPost() {
 		return
 	}
 
-	// Trimming extraneous spaces avoids all kinds of abuse
+	// Trimming extraneous spaces avoids some kinds of abuse/trolling
 	content := strings.TrimSpace(rw.params.Get("content"))
 	bc, ok := rw.conf.BoardConfig(rw.board)
 	if !ok {
@@ -125,8 +125,8 @@ func (rw *requestWorker) extractPost() {
 		rw.respondError(http.StatusNotFound)
 		return
 	}
-	if len(content) > bc.MaxPostBytes {
-		rw.err = errors.Errorf("post too large: %d bytes (max %d bytes)", len(content), bc.MaxPostBytes)
+	if len(content) > bc.MaxPostBytes() {
+		rw.err = errors.Errorf("post too large: %d bytes (max %d bytes)", len(content), bc.MaxPostBytes())
 		rw.respondError(http.StatusBadRequest)
 		return
 	} else if content == "" {

--- a/tchan/output/json/json.go
+++ b/tchan/output/json/json.go
@@ -20,7 +20,7 @@ func (w *Writer) write(obj interface{}) error {
 	return w.enc.Encode(obj)
 }
 
-func (w *Writer) WriteWelcome(boards []tchan.BoardConfig) error {
+func (w *Writer) WriteWelcome(boards []tchan.Board) error {
 	return w.write(boards)
 }
 

--- a/tchan/output/output.go
+++ b/tchan/output/output.go
@@ -12,7 +12,7 @@ import (
 
 // Writer describes an entity in charge of writing a server response.
 type Writer interface {
-	WriteWelcome(boards []tchan.BoardConfig) error
+	WriteWelcome(boards []tchan.Board) error
 	WriteThread(thread tchan.Thread) error
 	WriteBoard(board tchan.BoardOverview) error
 	WriteError(status int, err error) error
@@ -32,35 +32,33 @@ func writeTemplate(tdir string, fname string, content []byte) error {
 	return nil
 }
 
-// WriteTemplates dumps the default templates to a directory `template` inside
-// the given base directory.
-func WriteTemplates(baseDir string) error {
-	tdir := filepath.Join(baseDir, "template")
-	if exists, err := util.DirExists(tdir); err != nil {
-		return errors.Wrapf(err, "unable to check out template directory %s", tdir)
+// WriteTemplates dumps the default templates inside the given directory.
+func WriteTemplates(dir string) error {
+	if exists, err := util.DirExists(dir); err != nil {
+		return errors.Wrapf(err, "unable to check out template directory %s", dir)
 	} else if !exists {
-		if err := os.Mkdir(tdir, 0755); err != nil {
-			return errors.Wrapf(err, "unable to create template directory %s", tdir)
+		if err := os.Mkdir(dir, 0755); err != nil {
+			return errors.Wrapf(err, "unable to create template directory %s", dir)
 		}
 	}
 
-	if err := writeTemplate(tdir, "welcome.template", []byte(DefaultWelcome)); err != nil {
+	if err := writeTemplate(dir, "welcome.template", []byte(DefaultWelcome)); err != nil {
 		return err
 	}
 
-	if err := writeTemplate(tdir, "post.template", []byte(DefaultPost)); err != nil {
+	if err := writeTemplate(dir, "post.template", []byte(DefaultPost)); err != nil {
 		return err
 	}
 
-	if err := writeTemplate(tdir, "thread.template", []byte(DefaultThread)); err != nil {
+	if err := writeTemplate(dir, "thread.template", []byte(DefaultThread)); err != nil {
 		return err
 	}
 
-	if err := writeTemplate(tdir, "board.template", []byte(DefaultBoard)); err != nil {
+	if err := writeTemplate(dir, "board.template", []byte(DefaultBoard)); err != nil {
 		return err
 	}
 
-	if err := writeTemplate(tdir, "error.template", []byte(DefaultError)); err != nil {
+	if err := writeTemplate(dir, "error.template", []byte(DefaultError)); err != nil {
 		return err
 	}
 

--- a/tchan/tchan.go
+++ b/tchan/tchan.go
@@ -4,14 +4,47 @@ import (
 	"time"
 )
 
-// BoardConfig contains the configured settings for a board.
-type BoardConfig struct {
+const (
+	maxThreadsDefault      = 50
+	maxThreadLengthDefault = 100
+	maxPostBytesDefault    = 4096
+)
+
+// Board contains the configured settings for a board.
+type Board struct {
 	Name            string `json:"name"`
 	Descr           string `json:"description"`
-	Style           string `json:"-"`
-	MaxThreadCount  int    `json:"maxThreadCount"`
-	MaxThreadLength int    `json:"maxThreadLength"`
-	MaxPostBytes    int    `json:"maxPostBytes"`
+	Style           string `json:"style"`
+	ThreadsMax      int    `json:"maxThreads,omitempty"`
+	ThreadLengthMax int    `json:"maxThreadLength,omitempty"`
+	PostBytesMax    int    `json:"maxPostBytes,omitempty"`
+}
+
+// MaxThreads returns the maximum number of active threads to be displayed on
+// this board.
+func (b Board) MaxThreads() int {
+	if b.ThreadsMax > 0 {
+		return b.ThreadsMax
+	}
+	return maxThreadsDefault
+}
+
+// MaxThreadLength returns the maximum number of posts a thread can have and
+// be considered active.
+func (b Board) MaxThreadLength() int {
+	if b.ThreadLengthMax > 0 {
+		return b.ThreadLengthMax
+	}
+	return maxThreadsDefault
+}
+
+// MaxPostBytes returns the maximum length (in bytes) for post content on this
+// board.
+func (b Board) MaxPostBytes() int {
+	if b.PostBytesMax > 0 {
+		return b.PostBytesMax
+	}
+	return maxPostBytesDefault
 }
 
 // Post contains all data of a single post.
@@ -24,9 +57,9 @@ type Post struct {
 
 // Thread contains all data of a single thread.
 type Thread struct {
-	Board BoardConfig `json:"board"`
-	Topic string      `json:"topic"`
-	Posts []Post      `json:"posts"`
+	Board Board  `json:"board"`
+	Topic string `json:"topic"`
+	Posts []Post `json:"posts"`
 }
 
 // ID returns the thread's associated ID, i.e. the OP's post ID.
@@ -54,6 +87,6 @@ func (t ThreadSummary) ID() int64 {
 
 // BoardOverview contains superficial board data.
 type BoardOverview struct {
-	BoardConfig                 // embedded
-	Threads     []ThreadSummary `json:"threads"`
+	Board                   // embedded
+	Threads []ThreadSummary `json:"threads"`
 }


### PR DESCRIPTION
Moves to a JSON-based configuration for transport options and the board list.

Listening on a Unix socket is now possible. This will probably never be supported by the termchan-cli client but curl can handle it for e.g. debugging in a reverse proxy setup
For easier managing of operation modes, termchan now uses CLI commands. The default ./termchan operation mode is now ./termchan serve-http  with more modes available.